### PR TITLE
add status to reports table and report_id to items table

### DIFF
--- a/db/migrate/20201215071122_add_status_to_report_table.rb
+++ b/db/migrate/20201215071122_add_status_to_report_table.rb
@@ -1,0 +1,6 @@
+class AddStatusToReportTable < ActiveRecord::Migration[6.0]
+  def change
+    add_column :reports, :status, :integer, default: Report::PENDING
+    change_column_null :reports, :status, false
+  end
+end

--- a/db/migrate/20201215075132_add_report_id_to_items_table.rb
+++ b/db/migrate/20201215075132_add_report_id_to_items_table.rb
@@ -1,0 +1,5 @@
+class AddReportIdToItemsTable < ActiveRecord::Migration[6.0]
+  def change
+    add_column :items, :report_id, :integer
+  end
+end


### PR DESCRIPTION
## Summary
This pull request updates the schema of the database. 

In Report, we add a new status column, default at Report::PENDING. The other value is Report::RESOLVED. The admin is the person who can set the report's status.
In Item, we add new report_id column. This will help facilitate moving views between the item and its report.
